### PR TITLE
Add adorned heading component

### DIFF
--- a/src/components/HeadingBBAStyle.js
+++ b/src/components/HeadingBBAStyle.js
@@ -4,9 +4,9 @@ import styles from '@/styles/HeadingBBAStyle.module.css';
  * Component that displays a styled heading with an adornment in one of its sides.
  * @param {string} className  Optional classes to style the heading.
  * @param {bool} inverted  Set to true to place the heading to the right.
- * @param {*} color  The CSS color of the adorning shape.
- * @param {*} lineWidth  The width in pixels of the adorning shape.
- * @param {*} children  Heading text or other content.
+ * @param {string} color  The CSS color of the adorning shape.
+ * @param {int} lineWidth  The width in pixels of the adorning shape.
+ * @param {ReactNode} children  Heading text or other content.
  * @returns  A heading with an adornment in one of its sides.
  */
 export default function HeadingBBAStyle({

--- a/src/components/HeadingBBAStyle.js
+++ b/src/components/HeadingBBAStyle.js
@@ -1,0 +1,43 @@
+import styles from '@/styles/HeadingBBAStyle.module.css';
+
+/**
+ * Component that displays a styled heading with an adornment in one of its sides.
+ * @param {string} textContent  The text of the heading.
+ * @param {string} className  Optional classes to style the heading.
+ * @param {bool} inverted  Set to true to place the heading to the right.
+ * @param {*} color  The CSS color of the adorning shape.
+ * @param {*} lineWidth  The width in pixels of the adorning shape.
+ * @returns  A heading with an adornment in one of its sides.
+ */
+export default function HeadingBBAStyle({
+  textContent = '',
+  className = 'text-5xl font-black',
+  inverted = false,
+  color = 'var(--primary-color-dark)',
+  lineWidth = 30,
+}) {
+  return (
+    <div
+      className={`${inverted ? `${styles['invert']}` : ''} ${
+        styles['wrapper']
+      } ${className} flex`}
+    >
+      <h2 className={`${styles['text']}`} style={{ whiteSpace: 'nowrap' }}>
+        {textContent}
+      </h2>
+      <div
+        className={`${styles['shape-wrapper']} flex items-center w-full`}
+        style={{ fontSize: `${lineWidth}px` }}
+      >
+        <div
+          className={`${styles['circle']}`}
+          style={{ backgroundColor: `${color}` }}
+        ></div>
+        <div
+          className={`${styles['line']}`}
+          style={{ backgroundColor: `${color}` }}
+        ></div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HeadingBBAStyle.js
+++ b/src/components/HeadingBBAStyle.js
@@ -2,19 +2,19 @@ import styles from '@/styles/HeadingBBAStyle.module.css';
 
 /**
  * Component that displays a styled heading with an adornment in one of its sides.
- * @param {string} textContent  The text of the heading.
  * @param {string} className  Optional classes to style the heading.
  * @param {bool} inverted  Set to true to place the heading to the right.
  * @param {*} color  The CSS color of the adorning shape.
  * @param {*} lineWidth  The width in pixels of the adorning shape.
+ * @param {*} children  Heading text or other content.
  * @returns  A heading with an adornment in one of its sides.
  */
 export default function HeadingBBAStyle({
-  textContent = '',
   className = 'text-5xl font-black',
   inverted = false,
   color = 'var(--primary-color-dark)',
   lineWidth = 30,
+  children,
 }) {
   return (
     <div
@@ -23,7 +23,7 @@ export default function HeadingBBAStyle({
       } ${className} flex`}
     >
       <h2 className={`${styles['text']}`} style={{ whiteSpace: 'nowrap' }}>
-        {textContent}
+        {children}
       </h2>
       <div
         className={`${styles['shape-wrapper']} flex items-center w-full`}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,12 +24,13 @@ export default function Home() {
         {/* Placeholder element */}
         <div className="container mx-auto" style={{ height: '600px' }}>
           {/* Sample Heading component */}
-          <HeadingBBAStyle textContent="Follow us on Instagram" />
+          <HeadingBBAStyle>Follow us on Instagram</HeadingBBAStyle>
           <HeadingBBAStyle
-            textContent="@rrcbba"
             className="text-[2.5rem] font-bold text-sky-500"
             inverted={true}
-          />
+          >
+            @rrcbba
+          </HeadingBBAStyle>
         </div>{' '}
       </main>
       <FooterNavigation />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,6 +6,7 @@ import styles from '@/styles/Home.module.css';
 // Components
 import TopNavigation from '@/components/TopNavigation';
 import FooterNavigation from '@/components/FooterNavigation';
+import HeadingBBAStyle from '@/components/HeadingBBAStyle';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -20,7 +21,16 @@ export default function Home() {
       </Head>
       <TopNavigation />
       <main>
-        <div style={{ height: '600px' }}></div> {/* Placeholder element */}
+        {/* Placeholder element */}
+        <div className="container mx-auto" style={{ height: '600px' }}>
+          {/* Sample Heading component */}
+          <HeadingBBAStyle textContent="Follow us on Instagram" />
+          <HeadingBBAStyle
+            textContent="@rrcbba"
+            className="text-[2.5rem] font-bold text-sky-500"
+            inverted={true}
+          />
+        </div>{' '}
       </main>
       <FooterNavigation />
     </>

--- a/src/styles/HeadingBBAStyle.module.css
+++ b/src/styles/HeadingBBAStyle.module.css
@@ -1,0 +1,37 @@
+.wrapper {
+  --side-margin: 5rem;
+}
+
+.shape-wrapper {
+  position: relative;
+  margin-left: var(--side-margin);
+}
+
+.circle {
+  --size: 1em;
+  border-radius: 50%;
+  position: absolute;
+  left: calc(-0.5 * var(--size));
+  height: var(--size);
+  width: var(--size);
+}
+
+.line {
+  height: 0.2em;
+  width: 100%;
+}
+
+/* Styles when the text placement is inverted */
+.invert .text {
+  order: 2;
+}
+
+.invert .shape-wrapper {
+  margin-left: 0;
+  margin-right: var(--side-margin);
+}
+
+.invert .circle {
+  left: auto;
+  right: calc(-0.5 * var(--size));
+}


### PR DESCRIPTION
### Changes
- Added the component for the branding shape beside the titles currently seen on the Instragram section of the mockup.

### Missing
- The colours are currently tied to the globally set colours. We may have to replace the colours on this and other files that make use of those colours when we implement a palette. This is a simple one-line change and should not suppose a serious concern, but we should probably consider implementing the colour palette in the short term to minimize future changes. 
- Partially responsive as the component adjusts horizontally, which will require implementing media queries in the future for reducing the title size.