### PR TITLE
Migrate to @next/font for Google Font imports

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,5 +1,27 @@
 import '@/styles/globals.css';
+import { Fira_Sans, Work_Sans } from '@next/font/google';
+
+const primaryFont = Fira_Sans({
+  style: ['normal', 'italic'],
+  weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
+  subsets: ['latin'],
+});
+
+// Work Sans is a variable type font, therefore we don't need to specify styles or weights
+const secondaryFont = Work_Sans({
+  subsets: ['latin'],
+});
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <style jsx global>{`
+        :root {
+          --font-primary: ${primaryFont.style.fontFamily};
+          --font-secondary: ${secondaryFont.style.fontFamily};
+        }
+      `}</style>
+      <Component {...pageProps} />;
+    </>
+  );
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,5 @@
 import Head from 'next/head';
 import Image from 'next/image';
-import { Inter } from '@next/font/google';
 import styles from '@/styles/Home.module.css';
 
 // Components
@@ -8,8 +7,6 @@ import TopNavigation from '@/components/TopNavigation';
 import FooterNavigation from '@/components/FooterNavigation';
 import Button from '@/components/Button';
 import HeadingBBAStyle from '@/components/HeadingBBAStyle';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export default function Home() {
   return (
@@ -25,7 +22,7 @@ export default function Home() {
         {/* Placeholder element */}
         <div className="container mx-auto">
           {/* Sample buttons */}
-          <h5 className="text-lg mb-2">
+          <h5 className="mb-2 text-lg">
             <b>Variant &quot;primary&quot;</b> - Simple link buttons with
             default parameters.
           </h5>
@@ -41,7 +38,7 @@ export default function Home() {
             </Button>
           </div>
 
-          <h5 className="text-lg mb-2">
+          <h5 className="mb-2 text-lg">
             <b>Variant &quot;primary-outline&quot;</b> - Buttons with outline.
           </h5>
           <div className="mb-5 flex items-start">
@@ -56,7 +53,7 @@ export default function Home() {
             </Button>
           </div>
 
-          <h5 className="text-lg mb-2">
+          <h5 className="mb-2 text-lg">
             <b>Variant &quot;dark&quot;</b> - Sample non-link button with custom
             padding and onClick function
           </h5>
@@ -70,7 +67,7 @@ export default function Home() {
             </Button>
           </div>
 
-          <h5 className="text-lg mb-2">
+          <h5 className="mb-2 text-lg">
             <b>Variant &quot;dark&quot;</b> - Sample large button with image
           </h5>
           <div className="mb-5">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,24 +1,23 @@
-/* 
- * Import Google Fonts: Fira Sans, Work Sans 
- * Usage: 
- * font-family: 'Fira Sans', sans-serif;
- * font-family: 'Work Sans', sans-serif;
- */
-@import url('https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,100;0,200;0,400;0,600;0,700;0,800;0,900;1,200;1,400;1,700&family=Work+Sans:ital,wght@0,100;0,200;0,400;0,600;0,800;1,200;1,400;1,600&display=swap');
+/* Google Fonts imported with @next/font in _app.js
+ * Usage:
+ * --font-primary   = Fira Sans
+ * --font-secondary = Work Sans 
+*/
 
 /* Inject Tailwind's styles */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-body {
-  /* Variables */
+/* Global Variables */
+:root {
   --primary-color-light: #2d688d;
   --primary-color-dark: #4ba7e1;
   --bg-color-dark: #202020;
+}
 
-  /* Styles */
-  font-family: 'Fira Sans', sans-serif;
+body {
+  font-family: var(--font-primary), sans-serif;
 }
 
 .text-primary-light,


### PR DESCRIPTION
### Changes

- Use `@next/font` imports to download the CSS and font files at build time and serve them with the rest of our static assets, avoiding requests to Google from the client
- Create CSS variables for Fira Sans `--font-primary` and Work Sans `--font-secondary`
- Cleanup stray template code and sort Tailwind classes in `index.js`