### PR TITLE
Implement color palette and adjust color references

### DIFF
--- a/src/components/FooterNavigation.js
+++ b/src/components/FooterNavigation.js
@@ -20,7 +20,7 @@ export default function FooterNavigation() {
         <li className="mb-1 flex-initial" key={i}>
           <Link
             href={link.href}
-            className="linear text-gray-400 duration-100 hover:text-white"
+            className="linear text-gray-400 duration-100 hover:text-light"
           >
             {link.label}
           </Link>
@@ -76,7 +76,7 @@ export default function FooterNavigation() {
           Made with ❤️ by our{' '}
           <Link
             href="#"
-            className="linear underline underline-offset-2 duration-300 hover:text-white"
+            className="linear underline underline-offset-2 duration-300 hover:text-light"
           >
             contributors
           </Link>

--- a/src/components/FooterNavigation.js
+++ b/src/components/FooterNavigation.js
@@ -8,17 +8,20 @@ export default function FooterNavigation() {
   /**
    * Footer navigation column component
    * @param {string} header  Header text for the column
-   * @param {object} links   Object with link label and href props
+   * @param {object} links  Object with link label and href props
    * @returns  The footer navigation column.
    */
   const FooterNavColumn = ({ header, links }) => (
     <ul className="mx-10 flex flex-col">
       <li className="mb-2 flex-initial">
-        <p className="cursor-default text-lg font-bold text-white">{header}</p>
+        <p className="cursor-default text-lg font-bold text-light">{header}</p>
       </li>
       {links.map((link, i) => (
         <li className="mb-1 flex-initial" key={i}>
-          <Link href={link.href} className="linear text-gray-300 duration-200">
+          <Link
+            href={link.href}
+            className="linear text-gray-400 duration-100 hover:text-white"
+          >
             {link.label}
           </Link>
         </li>
@@ -27,7 +30,7 @@ export default function FooterNavigation() {
   );
 
   return (
-    <nav className="dark bg-zinc-900">
+    <nav className="bg-dark">
       <div className="container mx-auto flex py-12 px-16">
         <FooterNavColumn
           header="Club"
@@ -73,7 +76,7 @@ export default function FooterNavigation() {
           Made with ❤️ by our{' '}
           <Link
             href="#"
-            className="linear underline underline-offset-2 duration-300"
+            className="linear underline underline-offset-2 duration-300 hover:text-white"
           >
             contributors
           </Link>

--- a/src/components/FooterNavigation.js
+++ b/src/components/FooterNavigation.js
@@ -14,13 +14,15 @@ export default function FooterNavigation() {
   const FooterNavColumn = ({ header, links }) => (
     <ul className="mx-10 flex flex-col">
       <li className="mb-2 flex-initial">
-        <p className="cursor-default text-lg font-bold text-light">{header}</p>
+        <p className="cursor-default text-lg font-bold text-light-font">
+          {header}
+        </p>
       </li>
       {links.map((link, i) => (
         <li className="mb-1 flex-initial" key={i}>
           <Link
             href={link.href}
-            className="linear text-gray-400 duration-100 hover:text-light"
+            className="linear text-gray-400 duration-100 hover:text-light-font"
           >
             {link.label}
           </Link>
@@ -76,7 +78,7 @@ export default function FooterNavigation() {
           Made with ❤️ by our{' '}
           <Link
             href="#"
-            className="linear underline underline-offset-2 duration-300 hover:text-light"
+            className="linear underline underline-offset-2 duration-300 hover:text-light-font"
           >
             contributors
           </Link>

--- a/src/components/HeadingBBAStyle.js
+++ b/src/components/HeadingBBAStyle.js
@@ -12,7 +12,7 @@ import styles from '@/styles/HeadingBBAStyle.module.css';
 export default function HeadingBBAStyle({
   className = 'text-5xl font-black',
   inverted = false,
-  color = 'var(--primary-color-dark)',
+  color = 'var(--primary-color)',
   lineWidth = 30,
   children,
 }) {

--- a/src/components/TopNavigation.js
+++ b/src/components/TopNavigation.js
@@ -8,15 +8,15 @@ export default function TopNavigation() {
   /**
    * Component that generates text links in the top navigation.
    * @param {string} label  The text that will appear on the link.
-   * @param {string} href   The URL where the user will be redirected when clicking on the link.
+   * @param {string} href  The URL where the user will be redirected when clicking on the link.
    * @returns A text link.
    */
   const TextLink = ({ label, href }) => (
-    <li className="border-slate-800">
+    <li>
       <Link
         href={href}
         className={
-          'linear mx-2  p-3.5 font-medium text-slate-900 no-underline duration-100 hover:text-slate-500'
+          'linear mx-2 p-3.5 font-normal text-dark no-underline duration-100 hover:text-[var(--dark-font-hover-color)]'
         }
       >
         {label}
@@ -58,7 +58,7 @@ export default function TopNavigation() {
   );
 
   return (
-    <nav className="bg-white">
+    <nav className="bg-light">
       <div
         className={
           'container mx-auto flex h-32 flex-1 items-center justify-between py-4 px-5 text-xl font-medium'

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -256,7 +256,7 @@ export default function Home() {
           <p className="my-2 text-xl font-bold">Tailwind classes</p>
           <div className="flex">
             <div
-              className="mb-10 mr-10 flex flex-col text-light"
+              className="mb-10 mr-10 flex flex-col text-light-font"
               style={{
                 height: '20em',
                 width: '20em',
@@ -280,7 +280,7 @@ export default function Home() {
             </div>
 
             <div
-              className="mb-10 mr-10 flex flex-col text-light"
+              className="mb-10 mr-10 flex flex-col text-light-font"
               style={{
                 height: '20em',
                 width: '20em',
@@ -326,8 +326,10 @@ export default function Home() {
                   width: '20em',
                 }}
               >
-                <p className="text-2xl text-light">text-light</p>
-                <p className="text-2xl text-light-hover">text-light-hover</p>
+                <p className="text-2xl text-light-font">text-light-font</p>
+                <p className="text-2xl text-light-font-hover">
+                  text-light-font-hover
+                </p>
               </div>
               <div
                 className="flex flex-col items-center justify-center bg-light"
@@ -336,7 +338,10 @@ export default function Home() {
                   width: '20em',
                 }}
               >
-                <p className="text-2xl text-dark">text-dark</p>
+                <p className="text-2xl text-dark">text-dark-font</p>
+                <p className="text-2xl text-dark-font-hover">
+                  text-dark-font-hover
+                </p>
               </div>
             </div>
           </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -22,6 +22,7 @@ export default function Home() {
         {/* Placeholder element */}
         <div className="container mx-auto">
           {/* Sample buttons */}
+          <p className="my-3 text-3xl font-bold">Buttons</p>
           <h5 className="mb-2 text-lg">
             <b>Variant &quot;primary&quot;</b> - Simple link buttons with
             default parameters.
@@ -70,7 +71,7 @@ export default function Home() {
           <h5 className="mb-2 text-lg">
             <b>Variant &quot;dark&quot;</b> - Sample large button with image
           </h5>
-          <div className="mb-5">
+          <div className="mb-10">
             <Button
               variant="dark"
               size="lg"
@@ -87,11 +88,264 @@ export default function Home() {
             </Button>
           </div>
 
+          {/* Color palette */}
+          <p className="my-4 text-3xl font-bold">Color palette</p>
+          <p className="my-2 text-xl font-bold">CSS variables</p>
+          <div className="flex">
+            <div
+              className="mb-10 mr-10 flex flex-col"
+              style={{
+                height: '20em',
+                width: '20em',
+                color: 'var(--light-font-color)',
+              }}
+            >
+              <div
+                style={{ background: 'var(--primary-color)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color
+              </div>
+              <div
+                style={{
+                  background: 'var(--primary-hover-color)',
+                }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-hover-color
+              </div>
+              <div
+                style={{
+                  background: 'var(--light-color)',
+                  color: 'var(--dark-font-color)',
+                }}
+                className="flex grow items-center justify-center"
+              >
+                --light-color
+              </div>
+              <div
+                style={{ background: 'var(--dark-color)' }}
+                className="flex grow items-center justify-center"
+              >
+                --dark-color
+              </div>
+              <div
+                style={{ background: 'var(--dark-hover-color)' }}
+                className="flex grow items-center justify-center"
+              >
+                --dark-hover-color
+              </div>
+            </div>
+
+            <div
+              className="mb-10 mr-10 flex flex-col"
+              style={{
+                height: '20em',
+                width: '20em',
+                color: 'var(--light-font-color)',
+              }}
+            >
+              <div
+                style={{ background: 'var(--primary-color-900)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color-900
+              </div>
+              <div
+                style={{ background: 'var(--primary-color-800)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color-800
+              </div>
+              <div
+                style={{ background: 'var(--primary-color-700)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color-700
+              </div>
+              <div
+                style={{ background: 'var(--primary-color-600)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color-600
+              </div>
+              <div
+                style={{ background: 'var(--primary-color-500)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color-500 (brand)
+              </div>
+              <div
+                style={{ background: 'var(--primary-color-400)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color-400
+              </div>
+              <div
+                style={{ background: 'var(--primary-color-300)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color-300
+              </div>
+              <div
+                style={{ background: 'var(--primary-color-200)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color-200
+              </div>
+              <div
+                style={{ background: 'var(--primary-color-100)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color-100
+              </div>
+              <div
+                style={{ background: 'var(--primary-color-50)' }}
+                className="flex grow items-center justify-center"
+              >
+                --primary-color-50
+              </div>
+            </div>
+
+            <div>
+              <div
+                className="flex flex-col items-center justify-center"
+                style={{
+                  height: '10em',
+                  width: '20em',
+                  background: 'var(--dark-color)',
+                }}
+              >
+                <p
+                  className="text-2xl"
+                  style={{ color: 'var(--light-font-color)' }}
+                >
+                  --light-font-color
+                </p>
+                <p
+                  className="text-2xl"
+                  style={{ color: 'var(--light-font-hover-color)' }}
+                >
+                  --light-font-hover-color
+                </p>
+              </div>
+              <div
+                className="flex flex-col items-center justify-center"
+                style={{
+                  height: '10em',
+                  width: '20em',
+                  background: 'var(--light-color)',
+                }}
+              >
+                <p
+                  className="text-2xl"
+                  style={{ color: 'var(--dark-font-color)' }}
+                >
+                  --dark-font-color
+                </p>
+                <p
+                  className="text-2xl"
+                  style={{ color: 'var(--dark-font-hover-color)' }}
+                >
+                  --dark-font-hover-color
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <p className="my-2 text-xl font-bold">Tailwind classes</p>
+          <div className="flex">
+            <div
+              className="mb-10 mr-10 flex flex-col text-light"
+              style={{
+                height: '20em',
+                width: '20em',
+              }}
+            >
+              <div className="flex grow items-center justify-center bg-primary">
+                bg-primary
+              </div>
+              <div className="flex grow items-center justify-center bg-primary-hover">
+                bg-primary-hover
+              </div>
+              <div className="flex grow items-center justify-center bg-light text-dark">
+                bg-light
+              </div>
+              <div className="flex grow items-center justify-center bg-dark">
+                bg-dark
+              </div>
+              <div className="flex grow items-center justify-center bg-dark-hover">
+                bg-dark-hover
+              </div>
+            </div>
+
+            <div
+              className="mb-10 mr-10 flex flex-col text-light"
+              style={{
+                height: '20em',
+                width: '20em',
+              }}
+            >
+              <div className="flex grow items-center justify-center bg-primary-900">
+                bg-primary-900
+              </div>
+              <div className="flex grow items-center justify-center bg-primary-800">
+                bg-primary-800
+              </div>
+              <div className="flex grow items-center justify-center bg-primary-700">
+                bg-primary-700
+              </div>
+              <div className="flex grow items-center justify-center bg-primary-600">
+                bg-primary-600
+              </div>
+              <div className="flex grow items-center justify-center bg-primary-500">
+                bg-primary-500 (brand)
+              </div>
+              <div className="flex grow items-center justify-center bg-primary-400">
+                bg-primary-400
+              </div>
+              <div className="flex grow items-center justify-center bg-primary-300">
+                bg-primary-300
+              </div>
+              <div className="flex grow items-center justify-center bg-primary-200">
+                bg-primary-200
+              </div>
+              <div className="flex grow items-center justify-center bg-primary-100">
+                bg-primary-100
+              </div>
+              <div className="flex grow items-center justify-center bg-primary-50">
+                bg-primary-50
+              </div>
+            </div>
+
+            <div>
+              <div
+                className="flex flex-col items-center justify-center bg-dark"
+                style={{
+                  height: '10em',
+                  width: '20em',
+                }}
+              >
+                <p className="text-2xl text-light">text-light</p>
+                <p className="text-2xl text-light-hover">text-light-hover</p>
+              </div>
+              <div
+                className="flex flex-col items-center justify-center bg-light"
+                style={{
+                  height: '10em',
+                  width: '20em',
+                }}
+              >
+                <p className="text-2xl text-dark">text-dark</p>
+              </div>
+            </div>
+          </div>
+
           {/* Sample Heading component */}
           <div className="my-10">
             <HeadingBBAStyle>Follow us on Instagram</HeadingBBAStyle>
             <HeadingBBAStyle
-              className="text-[2.5rem] font-bold text-sky-500"
+              className="text-[2.5rem] font-bold text-primary"
               inverted={true}
             >
               @rrcbba

--- a/src/styles/Button.module.css
+++ b/src/styles/Button.module.css
@@ -46,7 +46,7 @@
 
 .button-component.button-variant-primary-outline:hover {
   background-color: var(--primary-color);
-  color: white;
+  color: var(--light-font-color);
 }
 
 /* Variant "dark" */

--- a/src/styles/Button.module.css
+++ b/src/styles/Button.module.css
@@ -3,7 +3,7 @@
 .button-component[class*=' Button_button-variant-'] {
   border-radius: 50em;
   box-sizing: border-box;
-  color: white;
+  color: var(--light-font-color);
   font-weight: 800;
   display: inline-block;
   transition: all linear 0.2s;
@@ -12,7 +12,7 @@
 
 .button-component[class^='Button_button-variant-']:hover,
 .button-component[class*=' Button_button-variant-']:hover {
-  color: white;
+  color: var(--light-font-color);
 }
 
 /* Variant for different sizes */
@@ -30,30 +30,30 @@
 
 /* Variant "primary" */
 .button-component.button-variant-primary {
-  background-color: var(--primary-color-dark);
+  background-color: var(--primary-color);
 }
 
 .button-component.button-variant-primary:hover {
-  background-color: #3c89ba;
+  background-color: var(--primary-hover-color);
 }
 
 /* Variant "primary-outline" */
 .button-component.button-variant-primary-outline {
-  border: 0.1em solid var(--primary-color-dark);
-  color: var(--primary-color-dark);
+  border: 0.1em solid var(--primary-color);
+  color: var(--primary-color);
   font-weight: 600;
 }
 
 .button-component.button-variant-primary-outline:hover {
-  background-color: var(--primary-color-dark);
+  background-color: var(--primary-color);
   color: white;
 }
 
 /* Variant "dark" */
 .button-component.button-variant-dark {
-  background-color: var(--bg-color-dark);
+  background-color: var(--dark-color);
 }
 
 .button-component.button-variant-dark:hover {
-  background-color: rgb(91, 91, 103);
+  background-color: var(--dark-hover-color);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,35 +9,115 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Global Variables */
-:root {
-  --primary-color-light: #2d688d;
-  --primary-color-dark: #4ba7e1;
-  --bg-color-dark: #202020;
+:root,
+#root,
+#docs-root {
+  /* Variables for handling colors */
+  /* Primary color */
+  --primary-color-hue: 203;
+  --primary-color-saturation: 71%;
+  --primary-color-lightness: 60%;
+
+  /* Dark color */
+  --dark-color-hue: 0;
+  --dark-color-saturation: 0%;
+  --dark-color-lightness: 13%;
+
+  /* Change on hover */
+  --hover-modifier: 15%;
+
+  /* Color palette */
+  --primary-color: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    var(--primary-color-lightness)
+  );
+
+  --primary-hover-color: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    calc(var(--primary-color-lightness) - var(--hover-modifier))
+  );
+
+  --dark-color: hsl(
+    var(--dark-color-hue),
+    var(--dark-color-saturation),
+    var(--dark-color-lightness)
+  );
+
+  --dark-hover-color: hsl(
+    var(--dark-color-hue),
+    var(--dark-color-saturation),
+    calc(var(--dark-color-lightness) + var(--hover-modifier))
+  );
+
+  --light-color: #fff;
+
+  /* Font colors */
+  --dark-font-color: hsl(0, 0%, 13%);
+  --dark-font-hover-color: var(--primary-color-800);
+  --light-font-color: #fff;
+  --light-font-hover-color: var(--primary-color-300);
+
+  /* Graded primary palette */
+  --primary-color-900: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    calc(var(--primary-color-lightness) * 0.6)
+  );
+  --primary-color-800: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    calc(var(--primary-color-lightness) * 0.7)
+  );
+  --primary-color-700: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    calc(var(--primary-color-lightness) * 0.8)
+  );
+  --primary-color-600: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    calc(var(--primary-color-lightness) * 0.9)
+  );
+  --primary-color-500: var(--primary-color);
+  --primary-color-400: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    calc(var(--primary-color-lightness) * 1.1)
+  );
+  --primary-color-300: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    calc(var(--primary-color-lightness) * 1.2)
+  );
+  --primary-color-200: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    calc(var(--primary-color-lightness) * 1.3)
+  );
+  --primary-color-100: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    calc(var(--primary-color-lightness) * 1.4)
+  );
+  --primary-color-50: hsl(
+    var(--primary-color-hue),
+    var(--primary-color-saturation),
+    calc(var(--primary-color-lightness) * 1.5)
+  );
 }
 
 body {
   font-family: var(--font-primary), sans-serif;
+  background-color: var(--light-color);
+  color: var(--dark-font-color);
 }
 
-.text-primary-light,
 a:hover {
-  color: var(--primary-color-light);
+  color: var(--light-font-hover-color);
 }
 
-.text-primary-dark,
-.dark a:hover {
-  color: var(--primary-color-dark);
-}
-
-.bg-primary-light {
-  background-color: var(--primary-color-light);
-}
-
-.bg-primary-dark {
-  background-color: var(--primary-color-dark);
-}
-
-.bg-dark-button {
-  background-color: var(--bg-color-dark);
-}
+/* .dark a:hover {
+  color: var(--dark-font-hover-color);
+} */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,34 @@ module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     screens: customScreens,
-    extend: {},
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: 'var(--primary-color)',
+          light: 'var(--primary-color-100)',
+          dark: 'var(--primary-color-900)',
+          hover: 'var(--primary-hover-color)',
+          900: 'var(--primary-color-900)',
+          800: 'var(--primary-color-800)',
+          700: 'var(--primary-color-700)',
+          600: 'var(--primary-color-600)',
+          500: 'var(--primary-color-500)',
+          400: 'var(--primary-color-400)',
+          300: 'var(--primary-color-300)',
+          200: 'var(--primary-color-200)',
+          100: 'var(--primary-color-100)',
+          50: 'var(--primary-color-50)',
+        },
+        dark: {
+          DEFAULT: 'var(--dark-color)',
+          hover: 'var(--dark-hover-color)',
+        },
+        light: {
+          DEFAULT: 'var(--light-color)',
+          hover: 'var(--light-font-hover-color)',
+        },
+      },
+    },
   },
   plugins: [],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,13 +27,20 @@ module.exports = {
           100: 'var(--primary-color-100)',
           50: 'var(--primary-color-50)',
         },
+        light: {
+          DEFAULT: 'var(--light-color)',
+        },
         dark: {
           DEFAULT: 'var(--dark-color)',
           hover: 'var(--dark-hover-color)',
         },
-        light: {
+        'light-font': {
           DEFAULT: 'var(--light-color)',
           hover: 'var(--light-font-hover-color)',
+        },
+        'dark-font': {
+          DEFAULT: 'var(--dark-color)',
+          hover: 'var(--dark-font-hover-color)',
         },
       },
     },


### PR DESCRIPTION
### Changes
- Added a color palette that is referenced both as CSS variables as in Tailwind.
- Changed previous color references to use new color palette.

### Known issues
- Minor: Tailwind won't allow to make a different color with the same name for a background as for text, preventing from creating a text-dark-hover color. 