### PR TITLE
Fix bug where fonts occasionally didn't load

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -5,11 +5,13 @@ const primaryFont = Fira_Sans({
   style: ['normal', 'italic'],
   weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
   subsets: ['latin'],
+  display: 'swap',
 });
 
 // Work Sans is a variable type font, therefore we don't need to specify styles or weights
 const secondaryFont = Work_Sans({
   subsets: ['latin'],
+  display: 'swap',
 });
 
 export default function App({ Component, pageProps }) {


### PR DESCRIPTION
I encountered the same issue in another project, which was solved by adding a display property to the NextJS fonts.

Source: https://github.com/vercel/next.js/issues/44456#issuecomment-1368137653