### PR TITLE
Updated Instagram feed handler based on api data after the Instagram api change

### DIFF
--- a/src/pages/current-board.jsx
+++ b/src/pages/current-board.jsx
@@ -43,7 +43,7 @@ export default function CurrentBoardPage() {
             >
               <img
                 // className="w-full sm:w-[225px] sm:rounded-l-lg lg:w-[150px] xl:w-[225px]"
-                className="h-full sm:h-[225px] sm:w-[225px] sm:rounded-l-lg lg:h-[150px] lg:w-[150px] xl:h-[225px] xl:w-[225px]"
+                className="w-full sm:h-[225px] sm:w-[225px] sm:rounded-l-lg lg:h-[150px] lg:w-[150px] xl:h-[225px] xl:w-[225px]"
                 // src={member.photoUrl ?? '/images/default-avatar.png'}
                 src={
                   member.photoUrl && member.photoUrl.trim() !== ''

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -10,7 +10,8 @@ export async function getServerSideProps({ res }) {
   if (!process.env.BEHOLD_URL) return { props: { instaFeed: [] } };
 
   const response = await fetch(process.env.BEHOLD_URL);
-  const instaFeed = await response.json();
+  const responseJson = await response.json()
+  const instaFeed = responseJson.posts;
 
   return {
     props: { instaFeed },


### PR DESCRIPTION
I updated the getServerSideProps to parse the posts array from the json response instead of just parsing the json response as a whole before. I'm unsure if the data from behold is structured the same or not after the Instagram api change but this works for me locally 