### PR TITLE
Hotfix for Instagram feed

### DIFF
--- a/src/pages/current-board.jsx
+++ b/src/pages/current-board.jsx
@@ -43,7 +43,7 @@ export default function CurrentBoardPage() {
             >
               <img
                 // className="w-full sm:w-[225px] sm:rounded-l-lg lg:w-[150px] xl:w-[225px]"
-                className="h-full sm:h-[225px] sm:w-[225px] sm:rounded-l-lg lg:h-[150px] lg:w-[150px] xl:h-[225px] xl:w-[225px]"
+                className="w-full sm:h-[225px] sm:w-[225px] sm:rounded-l-lg lg:h-[150px] lg:w-[150px] xl:h-[225px] xl:w-[225px]"
                 // src={member.photoUrl ?? '/images/default-avatar.png'}
                 src={
                   member.photoUrl && member.photoUrl.trim() !== ''

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -10,7 +10,8 @@ export async function getServerSideProps({ res }) {
   if (!process.env.BEHOLD_URL) return { props: { instaFeed: [] } };
 
   const response = await fetch(process.env.BEHOLD_URL);
-  const instaFeed = await response.json();
+  const responseJson = await response.json()
+  const instaFeed = responseJson.posts;
 
   return {
     props: { instaFeed },


### PR DESCRIPTION
Resolves Instagram feed issue of not displaying the posts - #31 by @tysenh1

Seems like the issue was caused by a change in the API. We were using Behold.so Basic v1 API, but were migrated to Basic V2, which wraps the posts JSON objects into a "posts" key on the response.

See https://behold.so/docs/v2-feeds-migration-guide/