### PR TITLE
Revert "Updated Instagram feed handler based on api data after the Instagram api change"

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -10,8 +10,7 @@ export async function getServerSideProps({ res }) {
   if (!process.env.BEHOLD_URL) return { props: { instaFeed: [] } };
 
   const response = await fetch(process.env.BEHOLD_URL);
-  const responseJson = await response.json()
-  const instaFeed = responseJson.posts;
+  const instaFeed = await response.json();
 
   return {
     props: { instaFeed },


### PR DESCRIPTION
Reverts bits-and-bytes-association/bitsandbytesassociation.ca#31

While it works for me locally for a Behold.so test account I created, the deploy preview failed, seemingly due to the feed.slice() on \src\components\InstagramFeed.jsx

https://deploy-preview-33--bba-website-nextjs.netlify.app/

Reverting the changes for now. It may be that the production environment BEHOLD_URL key uses Behold Basic V1 API, while these changes are intended for Behold Basic V2 API.

Created issue #34 